### PR TITLE
Linking to base url of resources

### DIFF
--- a/docs/_config.yaml
+++ b/docs/_config.yaml
@@ -1,3 +1,8 @@
+title: Red Hat Developer Hub Documentation
+
+baseurl: ""
+url: "https://maarten-vandeperre.github.io/developer-hub-documentation/"
+
 # Ensure the assets folder is not excluded
 include:
   - assets

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -6,10 +6,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>{{ page.title }}</title>
-    <link rel="stylesheet" href="/assets/css/default-style.css"/>
+    <link rel="stylesheet" href="{{site.baseurl}}/assets/css/default-style.css"/>
     <!-- Boxicons CSS -->
     <link flex href="https://unpkg.com/boxicons@2.1.4/css/boxicons.min.css" rel="stylesheet"/>
-    <script src="/assets/js/default-style.js" defer></script>
+    <script src="{{site.baseurl}}/assets/js/default-style.js" defer></script>
 </head>
 <body>
 <nav class="sidebar locked">


### PR DESCRIPTION
This PR should fix the link to the static resources (located at the `assets` folder) dynamically when a page is rendered.